### PR TITLE
Make UI changes and fix recursive bug

### DIFF
--- a/browserAction/index.html
+++ b/browserAction/index.html
@@ -20,21 +20,9 @@
     <link rel="stylesheet" href="style.css" />
   </head>
   <body>
-    <div class="header-container">
-      <h1 class="table-title">f:reb/ocks</h1>
-      <div class="clipboard-container"></div>
-    </div>
-    <div class="button-container">
-      <button class="btn btn-outline-primary add-row-button">add phrase</button>
-      <button class="btn btn-outline-secondary enable-all-button">
-        enable a//
-      </button>
-      <button class="btn btn-outline-secondary disable-all-button">
-        disable a//
-      </button>
-    </div>
-
+    <button class="btn btn-outline-primary add-row-button">add a word or phrase to block</button>
     <div id="phrase-table"></div>
+    <div class="clipboard-container"></div>
   </body>
   <script type="text/javascript" src="table.js"></script>
   <script type="text/javascript" src="utils.js"></script>

--- a/browserAction/index.html
+++ b/browserAction/index.html
@@ -2,7 +2,6 @@
 <html>
   <head>
     <title>Fireblocks</title>
-
     <link
       rel="stylesheet"
       href="../dist/tabulator-tables/css/tabulator_semanticui.min.css"
@@ -20,9 +19,12 @@
     <link rel="stylesheet" href="style.css" />
   </head>
   <body>
-    <button class="btn btn-outline-primary add-row-button">add a word or phrase to block</button>
+    <button class="btn btn-outline-primary add-row-button">
+      add a word or phrase to block
+    </button>
     <div id="phrase-table"></div>
-    <div class="clipboard-container"></div>
+    <div class="clipboard-container">
+    </div>
   </body>
   <script type="text/javascript" src="table.js"></script>
   <script type="text/javascript" src="utils.js"></script>

--- a/browserAction/script.js
+++ b/browserAction/script.js
@@ -9,13 +9,9 @@ const clipboardButtons = [
   "\uD83D\uDCA9", // poop
   "!!! SPOILER ALERT !!!",
   "\uD83E\uDD21", // clown
-  "!!! WARNING !!!",
   "\uD83D\uDC80", // skull
-  "!!! CENSORED !!!",
-  "\uD83D\uDC4E", // thumbs down
   "NOPE, NOT TODAY",
-  "\u2605\u2605\u2605\u2605\u2605", // 5 stars
-  "\u2605\u2606\u2606\u2606\u2606", // 1 star out of 5
+  "\uD83D\uDC4E", // thumbs down
   "%$#@!",
   "\uD83C\uDF46", // eggplant
 ];
@@ -63,6 +59,11 @@ Array.from(copyButtons).forEach((button) => {
 browser.storage.local.get("replacees").then((result) => {
   const replacees = result.replacees || [];
   const table = makeTable(replacees);
+  // if table is empty, do not show the table
+  if (replacees.length === 0) {
+    document.getElementById("phrase-table").style.maxHeight = "0px";
+    document.getElementsByClassName("clipboard-container")[0].style.display = "none";
+  }
 
   // Save on edit, disallow cells with more than 75 characters
   table.on("cellEdited", function (cell) {
@@ -79,28 +80,11 @@ browser.storage.local.get("replacees").then((result) => {
     saveData(cell, replacees);
   });
 
-  // add phrase button adds new row
+  // add phrase button adds new row and shows table if it was hidden
   const addButton = document.getElementsByClassName("add-row-button");
   addButton[0].addEventListener("click", function () {
+    document.getElementById("phrase-table").style.maxHeight = "350px";
+    document.getElementsByClassName("clipboard-container")[0].style.display = "flex";
     addNewRow(table, replacees);
-  });
-
-  // enable all button enables all rows
-  const enableAllButton = document.getElementsByClassName("enable-all-button");
-  enableAllButton[0].addEventListener("click", function () {
-    table.getRows().forEach(function (row) {
-      row.update({ enable: true });
-      saveData(row.getCell("enable"), replacees);
-    });
-  });
-
-  // disable all button disables all rows
-  const disableAllButton =
-    document.getElementsByClassName("disable-all-button");
-  disableAllButton[0].addEventListener("click", function () {
-    table.getRows().forEach(function (row) {
-      row.update({ enable: false });
-      saveData(row.getCell("enable"), replacees);
-    });
   });
 });

--- a/browserAction/style.css
+++ b/browserAction/style.css
@@ -23,38 +23,18 @@
   font-size: 13px;
 }
 
-.header-container {
-  display: flex;
-  justify-content: left;
-  align-items: center;
-  margin-top: 10px;
-  margin-left: 2.5%;
-  width: 95%;
-}
-
-.table-title {
-  font-family: "Zilla Slab Header", sans-serif;
-  font-size: 23px;
-  color: #ffffff;
-  background-color: black;
-  width: max-content;
-  padding: 5px 10px;
-  margin-top: 7.5px;
-}
-
-.button-container {
-  display: grid;
-  grid-template-columns: 2fr 1fr 1fr;
-  grid-gap: 10px;
-  margin-left: 2.5%;
-  width: 95%;
-}
-
 .btn {
   font-family: "Zilla Slab Cell", sans-serif;
 }
 
 /* add phrase button */
+.add-row-button {
+  width: 95%;
+  margin-left: 2.5%;
+  margin-top: 10px;
+
+}
+
 .btn-outline-primary {
   color: #8b44db;
   border-color: #8b44db;
@@ -72,33 +52,17 @@
   background-color: #733ab5;
 }
 
-/* enable/disable button */
-.btn-outline-secondary {
-  color: #ff6a29;
-  border-color: #ff6a29;
-}
-
-.btn-outline-secondary:hover {
-  color: #fff;
-  background-color: #ff6a29;
-  border-color: #ff6a29;
-}
-
-.btn-outline-secondary:not(:disabled):active {
-  border-color: #e55e1c;
-  color: #fff;
-  background-color: #e55e1c;
-}
-
+/* clipboard buttons */
 .clipboard-container {
   display: flex;
   grid-gap: 10px;
-  margin-left: 1%;
+  width: 95%;
+  margin-left: 2.5%;
   overflow-x: auto;
   white-space: nowrap;
+  margin-bottom: 10px;
 }
 
-/* clipboard buttons */
 .btn-outline-info {
   font-family: "Zilla Slab Cell", sans-serif;
   color: #fea252;

--- a/browserAction/table.js
+++ b/browserAction/table.js
@@ -37,6 +37,7 @@ function makeTable(replacees) {
     }
   }
 
+  // when the block phrase cell is empty, grey out the text and italicize it
   const blockPhrasePlaceholderInput = function (cell, formatterParams) {
     const cellValue = cell.getValue();
     if (cellValue === "") {
@@ -52,15 +53,24 @@ function makeTable(replacees) {
     }
   };
 
-  const replacementPlaceholderInput = function (cell, formatterParams) {
+  // when the replacement cell is empty, grey out the text and italicize it
+  // based on the replaceWith column
+  const replacementPlaceholderInput = function (cell) {
     const cellValue = cell.getValue();
-    console.log("row data" + cell.getRow().getData()["replaceWith"]);
-    // if the cell is empty and the replace with option is not redact
-    if (cellValue === "" && cell.getRow().getData()["replaceWith"] === "Custom") {
-      // grey out text and italicize it
+    if (
+      cellValue === "" &&
+      cell.getRow().getData()["replaceWith"] === "Custom"
+    ) {
       cell.getElement().style.color = "#999";
       cell.getElement().style.fontStyle = "italic";
       return "enter replacement";
+    } else if (
+      cellValue === "" &&
+      cell.getRow().getData()["replaceWith"] === "Redact"
+    ) {
+      cell.getElement().style.color = "#999";
+      cell.getElement().style.fontStyle = "italic";
+      return "N/A: using redact";
     } else {
       //remove the greyed out text and italics
       cell.getElement().style.color = "";

--- a/browserAction/table.js
+++ b/browserAction/table.js
@@ -37,6 +37,38 @@ function makeTable(replacees) {
     }
   }
 
+  const blockPhrasePlaceholderInput = function (cell, formatterParams) {
+    const cellValue = cell.getValue();
+    if (cellValue === "") {
+      // grey out text and italicize it
+      cell.getElement().style.color = "#999";
+      cell.getElement().style.fontStyle = "italic";
+      return "enter phrase to block";
+    } else {
+      //remove the greyed out text and italics
+      cell.getElement().style.color = "";
+      cell.getElement().style.fontStyle = "";
+      return cellValue;
+    }
+  };
+
+  const replacementPlaceholderInput = function (cell, formatterParams) {
+    const cellValue = cell.getValue();
+    console.log("row data" + cell.getRow().getData()["replaceWith"]);
+    // if the cell is empty and the replace with option is not redact
+    if (cellValue === "" && cell.getRow().getData()["replaceWith"] === "Custom") {
+      // grey out text and italicize it
+      cell.getElement().style.color = "#999";
+      cell.getElement().style.fontStyle = "italic";
+      return "enter replacement";
+    } else {
+      //remove the greyed out text and italics
+      cell.getElement().style.color = "";
+      cell.getElement().style.fontStyle = "";
+      return cellValue;
+    }
+  };
+
   return new Tabulator("#phrase-table", {
     columns: [
       {
@@ -47,12 +79,17 @@ function makeTable(replacees) {
         hozAlign: "center",
         width: 87,
       },
-      { title: "Target", field: "target", editor: "input", width: 150 },
+      {
+        title: "Block Phrase",
+        field: "target",
+        formatter: blockPhrasePlaceholderInput,
+        editor: "input",
+        width: 170,
+      },
       {
         title: "Replace With",
         field: "replaceWith",
         editor: "list",
-        width: 128,
         editorParams: { values: { Redact: "Redact", Custom: "Custom" } },
         cellEdited: function (cell) {
           // if redact, clear the custom replacement cell
@@ -67,11 +104,13 @@ function makeTable(replacees) {
       {
         title: "Custom Replacement",
         field: "replacement",
+        formatter: replacementPlaceholderInput,
         editor: replacementEditor,
         editable: function (cell) {
           const selectValue = cell.getRow().getCell("replaceWith").getValue();
           return selectValue === "Custom";
         },
+        width: 180,
       },
       {
         title: "Replace Option",
@@ -79,36 +118,36 @@ function makeTable(replacees) {
         editor: "list",
         editorParams: {
           values: {
-            "Eliminate Block Phrase": "Eliminate Block Phrase",
-            "Destroy Context": "Destroy Context",
-            "Obliterate Entire Page": "Obliterate Entire Page",
+            "Block just phrase": "Block just phrase",
+            "Block entire section": "Block entire section",
+            "Block entire page": "Block entire page",
           },
         },
         // if the value is obliterate page, give an alert saying it
         // make break some pages
         cellEdited: function (cell) {
           const selectValue = cell.getValue();
-          if (selectValue === "Obliterate Entire Page") {
+          if (selectValue === "Block entire page") {
             alert(
               "Warning: This option may break some pages. Use with caution."
             );
           }
         },
       },
-      {
-        title: "Case Sensitive",
-        field: "caseSensitive",
-        formatter: "tickCross",
-        editor: true,
-        hozAlign: "center",
-      },
-      {
-        title: "Smart Case",
-        field: "smartCase",
-        formatter: "tickCross",
-        editor: true,
-        hozAlign: "center",
-      },
+      // {
+      //   title: "Case Sensitive",
+      //   field: "caseSensitive",
+      //   formatter: "tickCross",
+      //   editor: true,
+      //   hozAlign: "center",
+      // },
+      // {
+      //   title: "Smart Case",
+      //   field: "smartCase",
+      //   formatter: "tickCross",
+      //   editor: true,
+      //   hozAlign: "center",
+      // },
       {
         title: "",
         formatter: function (cell) {
@@ -119,16 +158,22 @@ function makeTable(replacees) {
           deleteButton.classList.add("remove-button");
           deleteButton.addEventListener("click", function () {
             deleteRow(cell.getRow(), replacees);
+            // if table is empty, hide it
+            if (replacees.length === 0) {
+              document.getElementById("phrase-table").style.maxHeight = "0px";
+              document.getElementsByClassName(
+                "clipboard-container"
+              )[0].style.display = "none";
+            }
           });
           return deleteButton;
         },
-        width: 10,
         hozAlign: "center",
         headerSort: false,
       },
     ],
     data: replacees,
-    layout: "fitDataTable",
+    layout: "fitDataFill",
     resizableColumns: true,
   });
 }

--- a/browserAction/utils.js
+++ b/browserAction/utils.js
@@ -5,9 +5,9 @@ function addNewRow(table, replacees) {
     id: lastId + 1,
     enable: false,
     target: "",
-    replaceWith: "Redact",
+    replaceWith: "Custom",
     replacement: "",
-    replaceOption: "Eliminate Block Phrase",
+    replaceOption: "Block just phrase",
     caseSensitive: false,
     smartCase: false,
   };

--- a/scripts/block_phrase_script.js
+++ b/scripts/block_phrase_script.js
@@ -21,7 +21,7 @@ function replaceBlockPhraseOnly(rootNode, replacee) {
     false
   );
 
-  const regexFlags = replacee.caseSensitive ? "gu" : "gui";
+  const regexFlags = "gi";
   const regex = new RegExp(replacee.target, regexFlags);
   const stragglerArray = [];
 
@@ -45,7 +45,6 @@ function replaceBlockPhraseOnly(rootNode, replacee) {
     }
 
     const textHasPhrase = node.textContent.match(regex);
-
     // If the block phrase exists, replace it bottom up
     if (textHasPhrase) {
       node.childNodes.forEach((child) => {
@@ -73,5 +72,28 @@ function replaceBlockPhraseOnly(rootNode, replacee) {
   }
 
   // Reverse the array so that we replace the deepest nodes first
-  replaceStragglers(stragglerArray.reverse(), replacee);
+    replaceStragglers(stragglerArray.reverse(), replacee);
+}
+
+// Do the same as above but lighten the scope due to
+// the target being a subset of the replacement
+function replaceBlockPhraseTextOnly(rootNode, replacee) {
+  const walker = document.createTreeWalker(
+    rootNode,
+    NodeFilter.SHOW_TEXT,
+    null,
+    false
+  );
+
+  const regexFlags = "gi";
+  const regex = new RegExp(replacee.target, regexFlags);
+
+  let textNode;
+  while ((textNode = walker.nextNode())) {
+    if (textNode.textContent.match(regex)) {
+      textNode.textContent = textNode.textContent.replace(regex, (match) => {
+        return blockReplaceWith(match, replacee);
+      });
+    }
+  }
 }

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1,13 +1,13 @@
 // Route the replacee to the appropriate replacement function
 function doReplacement(node, replacee) {
   switch (replacee.replaceOption) {
-    case "Obliterate Entire Page":
+    case "Block entire page":
       replacePage(node, replacee);
       observeChanges(node, replacee, replacePage);
-    case "Eliminate Block Phrase":
+    case "Block just phrase":
       replaceBlockPhraseOnly(node, replacee);
       observeChanges(node, replacee, replaceBlockPhraseOnly);
-    case "Destroy Context":
+    case "Block entire section":
       replaceContext(node, replacee);
       observeChanges(node, replacee, replaceContext);
   }

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -4,10 +4,10 @@ function doReplacement(node, replacee) {
     case "Block entire page":
       replacePage(node, replacee);
       observeChanges(node, replacee, replacePage);
-    case "Block just phrase":
+    case "Eliminate Block Phrase":
       replaceBlockPhraseOnly(node, replacee);
       observeChanges(node, replacee, replaceBlockPhraseOnly);
-    case "Block entire section":
+    case "Destroy Context":
       replaceContext(node, replacee);
       observeChanges(node, replacee, replaceContext);
   }
@@ -20,8 +20,8 @@ function startReplacement() {
     const replacees = result.replacees || [];
     replacees.forEach((replacee) => {
       if (replacee.enable && replacee.target) {
-      doReplacement(document.body, replacee);
-      doReplacement(document.head, replacee);
+        doReplacement(document.body, replacee);
+        doReplacement(document.head, replacee);
       }
     });
   });

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -3,15 +3,29 @@ function doReplacement(node, replacee) {
   switch (replacee.replaceOption) {
     case "Block entire page":
       replacePage(node, replacee);
-      observeChanges(node, replacee, replacePage);
-    case "Eliminate Block Phrase":
-      replaceBlockPhraseOnly(node, replacee);
-      observeChanges(node, replacee, replaceBlockPhraseOnly);
-    case "Destroy Context":
-      replaceContext(node, replacee);
-      observeChanges(node, replacee, replaceContext);
+      if (!isSubsetString(replacee.target, replacee.replacement)) {
+        observeChanges(node, replacee, replacePage);
+      }
+      return;
+    case "Block just phrase":
+      if (!isSubsetString(replacee.target, replacee.replacement)) {
+        replaceBlockPhraseOnly(node, replacee);
+        observeChanges(node, replacee, replaceBlockPhraseOnly);
+      } else {
+        replaceBlockPhraseTextOnly(node, replacee);
+      }
+      return;
+    case "Block entire section":
+      if (!isSubsetString(replacee.target, replacee.replacement)) {
+        replaceContext(node, replacee);
+        observeChanges(node, replacee, replaceContext);
+      } else {
+        replaceContextText(node, replacee);
+      }
+      return;
   }
 }
+
 
 // Retrieve all replacees from storage and replace the body
 // and head of the page for each

--- a/scripts/page_replace_script.js
+++ b/scripts/page_replace_script.js
@@ -1,7 +1,7 @@
 // Replaces the page that contains the block phrase with a replacement
 // where the replacement repeats to match the number of words
 function replacePage(rootNode, replacee) {
-  const regexFlags = replacee.caseSensitive ? "gu" : "gui";
+  const regexFlags = "i";
   const regex = new RegExp(replacee.target, regexFlags);
   if (!rootNode.textContent.match(regex)) {
     return;

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -76,6 +76,9 @@ function replaceByWord(text, replacement, smartCase) {
   for (let i = 0; i < numTextWords; i++) {
     const textWord = textWords[i];
     const replacementWord = replacementWords[i % numReplacementWords];
+    if (!textWord) {
+      continue;
+    }
 
     if (smartCase) {
       newSentence +=
@@ -114,7 +117,7 @@ function findSentenceStartAndEnd(text, match) {
 // Replace nodes that did not register as replaced due to
 // race conditions.
 function replaceStragglers(stragglerArray, replacee) {
-  const regexFlags = replacee.caseSensitive ? "g" : "gi";
+  const regexFlags = "i";
   const regex = new RegExp(replacee.target, regexFlags);
   stragglerArray.forEach((node) => {
     if (!node.textContent.match(regex)) {
@@ -137,4 +140,9 @@ function replaceStragglers(stragglerArray, replacee) {
       }
     });
   });
+}
+
+
+function isSubsetString(target, replacement) {
+  return replacement.includes(target);
 }

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -130,9 +130,9 @@ function replaceStragglers(stragglerArray, replacee) {
     }
 
     node.textContent = node.textContent.replace(regex, (match) => {
-      if (replacee.replaceOption === "Destroy Context") {
+      if (replacee.replaceOption === "Block entire section") {
         return contextReplaceWith(node.textContent, replacee);
-      } else if (replacee.replaceOption === "Eliminate Block Phrase") {
+      } else if (replacee.replaceOption === "Block just phrase") {
         return blockReplaceWith(match, replacee, node);
       }
     });


### PR DESCRIPTION
Cases where the target phrase is a subset of the replacement phrase led to crashing. This is fixed by lowering the scope of these phrases to just text nodes from every node so that they don't replace themselves.

The case sensitive features and smart casing have been removed for now to make it simpler for the user. Empty cells have instructional placeholder text. Enable and disable all buttons removed. Users take a top down approach to using the extension.

